### PR TITLE
feat: picker prototype for scale-transform on active state (SDS-12198)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@
 Prototyping Spectrum design ideas.
 
 Now building on Storybook.
+
+# Starting Storybook
+
+`cd storybook`
+
+`npm install` or `yarn install`.
+
+`npm run start` to run Storybook on port 6006

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@spectrum-css/icon": "^3.0.23",
     "@spectrum-css/page": "^5.0.11",
     "@spectrum-css/rating": "^3.0.24",
+    "@spectrum-css/picker": "^1.2.12",
     "@spectrum-css/sidenav": "^3.0.24",
     "@spectrum-css/swatch": "^1.1.4",
     "@spectrum-css/switch": "^2.0.0",

--- a/stories/Picker/Picker.css
+++ b/stories/Picker/Picker.css
@@ -1,0 +1,11 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/

--- a/stories/Picker/Picker.js
+++ b/stories/Picker/Picker.js
@@ -1,0 +1,71 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import "@spectrum-css/picker/dist/index-vars.css";
+import "@spectrum-css/typography/dist/index-vars.css";
+import "@spectrum-css/icon/dist/index-vars.css";
+import "./Picker.css";
+
+import Handlebars from "handlebars";
+
+Handlebars.registerHelper("percentage", (value) => value / 100);
+Handlebars.registerHelper("mapUIIconSize", (value) => {
+  const map = { XS: 75, S: 75, M: 100, L: 200, XL: 300 };
+  if (map.hasOwnProperty(value)) {
+    return map[value];
+  } else {
+    return 100;
+  }
+});
+
+export const createPicker = Handlebars.compile(/*HTML*/ ` 
+<style>
+  
+  :root {
+    --spectrum-global-animation-duration-50: 80ms;
+
+    --spectrum-picker-active-animation-ease: var(--spectrum-global-animation-{{ease}});
+    --spectrum-picker-active-animation-duration: {{duration}}ms;
+  }
+  .spectrum-Picker  {
+    transition: transform var(--spectrum-picker-active-animation-duration)
+      var(--spectrum-picker-active-animation-ease);
+  }
+
+  {{#if animateChevronOnly}}
+  .spectrum-Picker:active .spectrum-Picker-transform-box {
+    transform: scale({{percentage scaleMultiplier}});
+  }
+  {{else}}
+  .spectrum-Picker:active {
+    transform: scale({{percentage scaleMultiplier}});
+  }
+  {{/if}} 
+</style>
+
+<h4>Picker scale M</h4>
+<button class="spectrum-Picker spectrum-Picker--sizeM {{#if isOpen}} is-open{{/if}}" 
+ {{#if isDisabled}} disabled{{/if}} 
+  aria-haspopup="listbox" style="width: 240px">
+  <span class="spectrum-Picker-label {{#if isPlaceholder}} is-placeholder{{/if}}">{{label}}</span>
+
+  <span class="spectrum-Picker-transform-box spectrum-Picker-menuIcon">
+    <svg class="spectrum-Icon spectrum-UIIcon-ChevronDown100 " focusable="false" aria-hidden="true">
+      <use xlink:href="#spectrum-css-icon-Chevron100" />
+    </svg>
+  </span>
+
+  <svg class="spectrum-Icon spectrum-UIIcon-Dash{{mapUIIconSize size}} spectrum-Checkbox-partialCheckmark" focusable="false" aria-hidden="true">
+  <use xlink:href="#spectrum-css-icon-Dash{{mapUIIconSize size}}" />
+  </svg>
+
+</button>`);

--- a/stories/Picker/Picker.stories.js
+++ b/stories/Picker/Picker.stories.js
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { createPicker } from "./Picker";
+
+export default {
+  title: "Picker",
+  argTypes: {
+    scaleMultiplier: {
+      name: "active scale multiplier",
+      defaultValue: 95,
+      control: { type: "range", min: 70, max: 98 },
+    },
+    duration: {
+      name: "active duration (ms)",
+      defaultValue: 80,
+      control: { type: "range", min: 50, max: 200 },
+    },
+    ease: {
+      name: "active ease function",
+      defaultValue: "ease-out",
+      options: ["ease-in-out", "ease-in", "ease-out", "ease-linear"],
+      control: { type: "select" },
+    },
+    animateChevronOnly: {
+      name: "only animate chevron on active state",
+      defaultValue: true,
+      type: { name: "boolean" },
+    },
+    label: { control: "text" },
+    isDisabled: {
+      name: "is disabled",
+      defaultValue: false,
+      type: { name: "boolean" },
+    },
+    isOpen: {
+      name: "is open",
+      defaultValue: false,
+      type: { name: "boolean" },
+    },
+    isPlaceholder: {
+      name: "is placeholder",
+      defaultValue: false,
+      type: { name: "boolean" },
+    },
+  },
+};
+// More on component templates: https://storybook.js.org/docs/html/writing-stories/introduction#using-args
+const Template = ({ ...args }) => {
+  // You can either use a function to create DOM elements or use a plain html string!
+  // return `<div>${label}</div>`;
+  return createPicker({ ...args });
+};
+
+export const Standard = Template.bind({});
+// More on args: https://storybook.js.org/docs/html/writing-stories/args
+Standard.args = {
+  label: "Choose a country...",
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1912,6 +1912,11 @@
   dependencies:
     "@spectrum-css/vars" "^8.0.0"
 
+"@spectrum-css/picker@^1.2.12":
+  version "1.2.12"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/picker/-/picker-1.2.12.tgz#1d60daabb0b6e09a26b4f2380b80cb1baa3b8bc0"
+  integrity sha512-WdV16JVgdQp3XJ0ymfbbB4A1emXZAX2Z9cqDf+UsaFNg7wOkNrhXl5paj9J7wOdALHU6uJN1EfNRhWMrTZQxGw==
+
 "@spectrum-css/rating@^3.0.24":
   version "3.0.24"
   resolved "https://registry.yarnpkg.com/@spectrum-css/rating/-/rating-3.0.24.tgz#d6406c0907f9ca8df5c8e2402d237379283b504a"


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/SDS-12198 Spectrum Next Picker Prototype
## Description

<!--- Describe your changes in detail -->

Bouncy Picker button or Chevron only.
<img width="1391" alt="Screen Shot 2022-09-26 at 15 48 25" src="https://user-images.githubusercontent.com/52184321/192386777-dfd16cd1-de79-4a9b-9e3a-a28e45bad90a.png">



Added a tiny bit detail in ReadME.md
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
