### PR TITLE
feat: button and link animated arrow icon (SDS-12273)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@spectrum-css/checkbox": "^3.1.3",
     "@spectrum-css/expressvars": "^2.0.0",
     "@spectrum-css/icon": "^3.0.23",
+    "@spectrum-css/link": "^3.1.23",
     "@spectrum-css/page": "^5.0.11",
     "@spectrum-css/rating": "^3.0.24",
     "@spectrum-css/picker": "^1.2.12",

--- a/stories/Button/ButtonLinkIcon.js
+++ b/stories/Button/ButtonLinkIcon.js
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import "@spectrum-css/link/dist/index-vars.css";
+import "@spectrum-css/typography/dist/index-vars.css";
+import "@spectrum-css/icon/dist/index-vars.css";
+
+import Handlebars from "handlebars";
+
+export const createButtonIconAnimation = Handlebars.compile(/*HTML*/ ` 
+<style>
+  .spectrum-Button-label {
+    position: relative;
+  }
+
+  /* spacer for the icon */
+  .spectrum-Button-label:after {
+      display: inline-block;
+      content: "";
+      width: 15px;
+      height: 5px;
+  }
+
+  /* animate the icon */
+  .spectrum-Button svg {
+      display: inline-block;
+      position: absolute;
+      rotate: -45deg;
+      top: 2px;
+      right: -12px;
+      {{#if animateButtonIcon}}
+        transition: right {{duration}}ms {{ease}} 0s, top {{duration}}ms {{ease}} 0s;
+      {{/if}}
+  }
+
+  .spectrum-Button:{{triggerEvent}} svg {
+      top: -1px;
+      right: -15px;
+  }
+
+
+
+</style>
+
+<div class="spectrum-Examples-item">
+  <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Button with icon, animation optional <a href="https://jira.corp.adobe.com/browse/SDS-12274">(SDS-12274)</a></h4>
+
+  <br/>
+  <br/>
+
+
+  <button class="spectrum-Button spectrum-Button--{{variant}}{{#if staticColor}} spectrum-Button--{{staticColor}}{{/if}} spectrum-Button--{{style}} spectrum-Button--size{{size}}"{{#if isDisabled}} disabled{{/if}}>
+    <span class="spectrum-Button-label">{{label}}<svg class="spectrum-Icon spectrum-UIIcon-{{icon}} spectrum-Icon--sizeM " aria-hidden="true">
+    <use xlink:href="#spectrum-css-icon-{{icon}}" />
+  </svg></span>
+  </button>
+
+</div>
+
+<br/>
+
+
+`);

--- a/stories/Button/ButtonLinkIcon.stories.js
+++ b/stories/Button/ButtonLinkIcon.stories.js
@@ -1,0 +1,90 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { createButtonIconAnimation } from "./ButtonLinkIcon";
+
+export default {
+  title: "Button",
+  argTypes: {
+    duration: {
+      name: "hover animation duration (ms)",
+      defaultValue: 60,
+      control: { type: "range", min: 30, max: 300 },
+    },
+    triggerEvent: {
+      name: "trigger event",
+      defaultValue: "hover",
+      options: ["hover", "active"],
+      control: { type: "select" },
+    },
+    ease: {
+      name: "active ease function",
+      defaultValue: "ease-out",
+      options: ["ease-in-out", "ease-in", "ease-out", "ease-linear"],
+      control: { type: "select" },
+    },
+    icon: {
+      name: "button icon",
+      defaultValue: "Arrow100",
+      options: ["Arrow75", "Arrow100", "Arrow200", "Arrow300"],
+      control: { type: "select" },
+    },
+    animateButtonIcon: {
+      name: "animate the button icon on hover state",
+      defaultValue: true,
+      type: { name: "boolean" },
+    },
+    style: {
+      options: ["fill", "outline"],
+      defaultValue: "fill",
+      control: { type: "select" },
+    },
+    size: {
+      options: ["M"],
+      defaultValue: "M",
+      control: {
+        type: "select",
+        labels: {
+          M: "medium",
+        },
+      },
+    },
+    isJustified: {
+      name: "is justified",
+      defaultValue: false,
+      type: { name: "boolean" },
+    },
+    isPending: {
+      name: "is pending",
+      defaultValue: false,
+      type: { name: "boolean" },
+    },
+    isDisabled: {
+      name: "is disabled",
+      defaultValue: false,
+      type: { name: "boolean" },
+    },
+  },
+};
+// More on component templates: https://storybook.js.org/docs/html/writing-stories/introduction#using-args
+const Template = ({ ...args }) => {
+  // You can either use a function to create DOM elements or use a plain html string!
+  // return `<div>${label}</div>`;
+  return createButtonIconAnimation({ ...args });
+};
+
+export const ButtonIcon = Template.bind({});
+// More on args: https://storybook.js.org/docs/html/writing-stories/args
+ButtonIcon.args = {
+  label: "Button",
+  variant: "primary",
+};

--- a/stories/Link/Link.css
+++ b/stories/Link/Link.css
@@ -1,0 +1,11 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/

--- a/stories/Link/Link.js
+++ b/stories/Link/Link.js
@@ -1,0 +1,69 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import "@spectrum-css/link/dist/index-vars.css";
+import "@spectrum-css/typography/dist/index-vars.css";
+import "@spectrum-css/icon/dist/index-vars.css";
+import "./Link.css";
+
+import Handlebars from "handlebars";
+
+export const createLinkIconAnimation = Handlebars.compile(/*HTML*/ ` 
+<style>
+  
+  .spectrum-Link {
+    position: relative;
+  }
+
+  /* spacer for the icon */
+  .spectrum-Link:after {
+      display: inline-block;
+      content: "";
+      width: 15px;
+      height: 5px;
+  }
+
+  /* animate the icon */
+  .spectrum-Link svg {
+      display: inline-block;
+      position: absolute;
+      margin-left: 8px;
+      rotate: -45deg;
+      top: -1px;
+      {{#if animateLinkIcon}}
+        transition: padding {{duration}}ms {{ease}} 0s, top {{duration}}ms {{ease}} 0s;
+      {{/if}}
+  }
+
+  .spectrum-Link:{{triggerEvent}} svg {
+      top: -3px;
+      padding-left: 3px;
+  }
+</style>
+
+
+<div class="spectrum-Examples-item">
+  <h4 class="spectrum-Heading spectrum-Heading--sizeXS spectrum-Examples-itemHeading">Link with icon, animation optional <a href="https://jira.corp.adobe.com/browse/SDS-12274">(SDS-12274)</a></h4>
+
+  <br/>
+  <br/>
+
+  <a href="#" onClick="event.preventDefault()" class="spectrum-Link">
+    
+    {{linkText}}<svg class="spectrum-Icon spectrum-UIIcon-{{icon}} spectrum-Icon--sizeM " aria-hidden="true">
+      <use xlink:href="#spectrum-css-icon-{{icon}}" />
+    </svg>
+  </a>
+</div>
+
+<br/>
+`);

--- a/stories/Link/Link.stories.js
+++ b/stories/Link/Link.stories.js
@@ -1,0 +1,60 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { createLinkIconAnimation } from "./Link";
+
+export default {
+  title: "Link",
+  argTypes: {
+    duration: {
+      name: "hover animation duration (ms)",
+      defaultValue: 60,
+      control: { type: "range", min: 30, max: 300 },
+    },
+    triggerEvent: {
+      name: "trigger event",
+      defaultValue: "hover",
+      options: ["hover", "active"],
+      control: { type: "select" },
+    },
+    ease: {
+      name: "active ease function",
+      defaultValue: "ease-out",
+      options: ["ease-in-out", "ease-in", "ease-out", "ease-linear"],
+      control: { type: "select" },
+    },
+    icon: {
+      name: "link icon",
+      defaultValue: "Arrow100",
+      options: ["Arrow75", "Arrow100", "Arrow200", "Arrow300"],
+      control: { type: "select" },
+    },
+    animateLinkIcon: {
+      name: "animate the link icon on hover state",
+      defaultValue: true,
+      type: { name: "boolean" },
+    },
+  },
+};
+// More on component templates: https://storybook.js.org/docs/html/writing-stories/introduction#using-args
+const Template = ({ ...args }) => {
+  // You can either use a function to create DOM elements or use a plain html string!
+  // return `<div>${label}</div>`;
+  return createLinkIconAnimation({ ...args });
+};
+
+export const LinkIcon = Template.bind({});
+// More on args: https://storybook.js.org/docs/html/writing-stories/args
+LinkIcon.args = {
+  prelinkText: "For more information, visit the ",
+  linkText: "Adobe Help Center",
+};

--- a/stories/Picker/Picker.js
+++ b/stories/Picker/Picker.js
@@ -52,7 +52,7 @@ export const createPicker = Handlebars.compile(/*HTML*/ `
   {{/if}} 
 </style>
 
-<h4>Picker scale M</h4>
+<h4>Picker scaling effects in size M <a href="https://jira.corp.adobe.com/browse/SDS-12198">SDS-12198</a> </h4>
 <button class="spectrum-Picker spectrum-Picker--sizeM {{#if isOpen}} is-open{{/if}} {{#if isQuiet}}  spectrum-Picker--quiet{{/if}}" 
  {{#if isDisabled}} disabled{{/if}} 
   aria-haspopup="listbox" style="width: 240px">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1905,6 +1905,11 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-3.0.23.tgz#95a5e1aa7fa0eace579449b3aaa7ec87c8c77f7f"
   integrity sha512-HtH8M1+b2KxcOJjdaqqemp/Yx7TUBosHhlzuZcDxoG2OpSrg7LtkJfDyv+0qFELzB934k9JbiE4xVlHRzTcrZA==
 
+"@spectrum-css/link@^3.1.23":
+  version "3.1.23"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-3.1.23.tgz#9d9ff64c41366edbfdb19d04a5deec88bf2ea8fd"
+  integrity sha512-CAJQGnGTrTtR4tF1L94ou9Y+c4vnx9d5rWhb3AMzKb2Focqz02xSkTyaCCH7OM/3CwD8TCLOMANon8LcRpGAjA==
+
 "@spectrum-css/page@^5.0.11":
   version "5.0.11"
   resolved "https://registry.yarnpkg.com/@spectrum-css/page/-/page-5.0.11.tgz#81e74e596abd0fa208c666742caeae1013adaf1b"


### PR DESCRIPTION
Adding an icon animation prototype for Link and Button

https://jira.corp.adobe.com/browse/SDS-12274

## Description

Adding 2 stories for Link and Button.
Added a link in the title of the Story so we can keep track what the prototype was about in Jira.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

They made me do it. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<img width="422" alt="Screen Shot 2022-10-12 at 11 44 44" src="https://user-images.githubusercontent.com/52184321/195419391-e291b38f-1ab8-4288-8f82-3c0e1fce54ae.png">
<img width="412" alt="Screen Shot 2022-10-12 at 11 44 49" src="https://user-images.githubusercontent.com/52184321/195419407-09bfee79-2110-4e1c-a38b-8dd37618f9dd.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
